### PR TITLE
Binary entity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It works very well on mobile devices for a compact view of your current state an
 
 ## Installation
 
-### HACS 
+### HACS
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sxdjt&repository=horizontal-waterfall-history-card)
 
@@ -34,7 +34,7 @@ It works very well on mobile devices for a compact view of your current state an
    ```
 ## Configuration
 
-### Basic 
+### Basic
 ```yaml
 type: custom:waterfall-history-card
 entity: sensor.living_room_temperature
@@ -118,6 +118,7 @@ thresholds:
     color: "#FFB74D"
   - value: 100
     color: "#FF8A65"
+```
 
 ### Thresholds
 
@@ -128,3 +129,14 @@ thresholds:
 | 80        | `#FFB74D` |
 | 100       | `#FF8A65` |
 
+### Thresholds for binary entities
+
+When using a binary entity (on/off entity), the following default thresholds apply:
+
+```yaml
+thresholds:
+  - value: 0  # off
+    color: "#4FC3F7"
+  - value: 1  # on
+    color: "#81C784"
+```

--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -359,6 +359,11 @@ class WaterfallHistoryCard extends HTMLElement {
     if (typeof state === 'string') {
       if (state === 'off') return false;
       if (state === 'on') return true;
+
+      const casted = parseFloat(state);
+      if (!Number.isNaN(casted)) {
+        return casted;
+      }
     }
 
     console.error("Unknown state type " + typeof state + " - " + state);

--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -504,12 +504,7 @@ class WaterfallHistoryCard extends HTMLElement {
       show_min_max: true,
       gradient: false,
       digits: 1,
-      thresholds: [
-        { value: 60, color: '#4FC3F7' },
-        { value: 70, color: '#81C784' },
-        { value: 80, color: '#FFB74D' },
-        { value: 100, color: '#FF8A65' }
-      ]
+      thresholds: threshold_default_number,
     };
   }
 }

--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -176,8 +176,7 @@ class WaterfallHistoryCard extends HTMLElement {
     const minValForScale = this.config.min_value ?? Math.min(...processedData.filter(v => v !== null));
     const maxValForScale = this.config.max_value ?? Math.max(...processedData.filter(v => v !== null));
 
-    const actualMin = Math.min(...processedData.filter(v => v !== null && !isNaN(v)));
-    const actualMax = Math.max(...processedData.filter(v => v !== null && !isNaN(v)));
+    const [actualMin, actualMax] = this.getMinMax(processedData);
 
     this.shadowRoot.innerHTML = `
       <style>
@@ -302,7 +301,7 @@ class WaterfallHistoryCard extends HTMLElement {
 
       ${this.config.show_min_max ? `
         <div class="min-max-label">
-          ${this.config.compact ? '' : this.t('min_label') + ':'} ${actualMin.toFixed(this.config.digits)}${this.unit} - ${this.config.compact ? '' : this.t('max_label') + ':'} ${actualMax.toFixed(this.config.digits)}${this.unit}
+          ${this.config.compact ? '' : this.t('min_label') + ':'} ${this.displayState(actualMin)} - ${this.config.compact ? '' : this.t('max_label') + ':'} ${this.displayState(actualMax)}
         </div>
       ` : ''}
     `;
@@ -339,6 +338,17 @@ class WaterfallHistoryCard extends HTMLElement {
     }
 
     return processed;
+  }
+
+  getMinMax(data) {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const d of data) {
+      if (d === null) continue;
+      if (d > max) max = d;
+      if (d < min) min = d;
+    }
+    return [min, max];
   }
 
   parseState(state) {

--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -7,7 +7,7 @@ const threshold_default_number = [
 ];
 const threshold_default_boolean = [
   { value: 0, color: '#4FC3F7' },  // cold
-  { value: 1, color: '#FF8A65' },  // cool
+  { value: 1, color: '#FF8A65' },  // hot
 ];
 
 class WaterfallHistoryCard extends HTMLElement {
@@ -388,7 +388,7 @@ class WaterfallHistoryCard extends HTMLElement {
     let thresholds = this.config.thresholds;
     if (!thresholds) {
       if (typeof value === 'boolean') thresholds = threshold_default_boolean;
-      else thresholds = threshold_default_boolean;
+      else thresholds = threshold_default_number;
     }
     if (thresholds.length === 0) return '#666666';
 

--- a/horizontal-waterfall-history-card.js
+++ b/horizontal-waterfall-history-card.js
@@ -1,3 +1,15 @@
+
+const threshold_default_number = [
+  { value: 60, color: '#4FC3F7' },  // cold
+  { value: 70, color: '#81C784' },  // cool
+  { value: 80, color: '#FFB74D' },  // warm
+  { value: 100, color: '#FF8A65' }  // hot
+];
+const threshold_default_boolean = [
+  { value: 0, color: '#4FC3F7' },  // cold
+  { value: 1, color: '#FF8A65' },  // cool
+];
+
 class WaterfallHistoryCard extends HTMLElement {
   constructor() {
     super();
@@ -48,12 +60,7 @@ class WaterfallHistoryCard extends HTMLElement {
       height: config.height || 60,
       min_value: config.min_value || null,
       max_value: config.max_value || null,
-      thresholds: config.thresholds || [
-        { value: 60, color: '#4FC3F7' },  // cold
-        { value: 70, color: '#81C784' },  // cool
-        { value: 80, color: '#FFB74D' },  // warm
-        { value: 100, color: '#FF8A65' }  // hot
-      ],
+      thresholds: config.thresholds || null,
       gradient: config.gradient || false,
       show_current: config.show_current !== false,
       show_labels: config.show_labels !== false,
@@ -363,11 +370,15 @@ class WaterfallHistoryCard extends HTMLElement {
     if (value === null) return '#666666';
     if (isNaN(value)) return '#666666';
 
+    let thresholds = this.config.thresholds;
+    if (!thresholds) {
+      if (typeof value === 'boolean') thresholds = threshold_default_boolean;
+      else thresholds = threshold_default_boolean;
+    }
+    if (thresholds.length === 0) return '#666666';
+
     if (value === false) value = 0;
     if (value === true) value = 1;
-
-    const thresholds = this.config.thresholds;
-    if (!thresholds || thresholds.length === 0) return '#666666';
 
     if (!this.config.gradient) {
       for (let i = thresholds.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Closes #6 

I also want binary entity support, and I had some time :)

Please don't hesitate to request changes based on anything. I've deviated from your coding style in places.

I have not considered the default colors for binary entities carefully; I just picked them from the number defaults.

![image](https://github.com/user-attachments/assets/e597e8e0-c39d-4300-b34c-9a0b362df467)

```yaml
type: custom:waterfall-history-card
entity: input_boolean.dev_toggle
title: Dev toggle
hours: 1
intervals: 60
show_min_max: true
gradient: false
```